### PR TITLE
RenderEngine: Don't crash skiagl backend

### DIFF
--- a/libs/renderengine/include/renderengine/RenderEngine.h
+++ b/libs/renderengine/include/renderengine/RenderEngine.h
@@ -98,7 +98,7 @@ public:
         SKIA_GL_THREADED = 4,
     };
 
-    static std::unique_ptr<RenderEngine> create(const RenderEngineCreationArgs& args);
+    static std::unique_ptr<RenderEngine> create(RenderEngineCreationArgs args);
 
     virtual ~RenderEngine() = 0;
 


### PR DESCRIPTION
The skiagl backend was incorrectly being created as skiaglthreaded,
which breaks mapping ExternalTextures off-thread. Specifically, there is
a workaround that disables mapping ExternalTextures at all when the
skiagl backend is used. Don't break that workaround by propagating the
renderengine type properly to implementations.

Bug: 205591213
Bug: 196334700
Bug: 193212592
Test: `adb shell stop; adb shell setprop debug.renderengine.backend
skiagl; adb shell start` boots

As listed below, compiled and tested with Skia GL & Skia GL Threaded. Device works correctly, no random reboots and glithces detected.