### PR TITLE
libbinder: Suppress log spam when unlinking death recipients

### DIFF
--- a/libs/binder/BpBinder.cpp
+++ b/libs/binder/BpBinder.cpp
@@ -492,7 +492,7 @@ void BpBinder::onLastStrongRef(const void* /*id*/)
     Vector<Obituary>* obits = mObituaries;
     if(obits != nullptr) {
         if (!obits->isEmpty()) {
-            ALOGI("onLastStrongRef automatically unlinking death recipients: %s",
+            ALOGV("onLastStrongRef automatically unlinking death recipients: %s",
                   mDescriptorCache.size() ? String8(mDescriptorCache).c_str() : "<uncached descriptor>");
         }
 


### PR DESCRIPTION
Remove additional logspam by binder.

Test: Compile, boot, check logs.